### PR TITLE
Only hide the first toolbar in the document

### DIFF
--- a/style/style.css
+++ b/style/style.css
@@ -4,7 +4,7 @@
   background: var(--jp-layout-color1);
 }
 
-.specta-document-viewer #jp-main-content-panel jp-toolbar {
+.specta-document-viewer #jp-main-content-panel jp-toolbar:first-of-type {
   display: none;
 }
 


### PR DESCRIPTION
Prevent hiding toolbars in cell outputs (jupytercad/jupytergis)