### PR TITLE
Allow for dynamic view switching

### DIFF
--- a/src/document/factory.tsx
+++ b/src/document/factory.tsx
@@ -35,6 +35,7 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
     this._shell = options.shell;
     this._themeManager = options.themeManager;
     this._spectaTopbar = options.spectaTopbar;
+    this._layoutRegistry = options.spectaLayoutRegistry;
   }
 
   protected createNewWidget(
@@ -50,12 +51,19 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
         nbPath: path
       });
       const isSpecta = isSpectaApp();
+
+      const spectaWidget = await this._spectaWidgetFactory.createNew({
+        context
+      });
+
       if (!spectaConfig.hideTopbar) {
         const title = <TitleComponent config={spectaConfig.topBar} />;
         const menu = (
           <MenuComponent
             config={spectaConfig.topBar}
             themeManager={this._themeManager}
+            layoutRegistry={this._layoutRegistry}
+            spectaWidget={spectaWidget}
           />
         );
         if (!isSpecta) {
@@ -76,10 +84,6 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
         this._shell.hideTopBar();
       }
 
-      const spectaWidget = await this._spectaWidgetFactory.createNew({
-        context
-      });
-
       if (spectaWidget) {
         content.addWidget(spectaWidget);
       }
@@ -97,4 +101,5 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
   private _shell: ISpectaShell;
   private _themeManager?: IThemeManager;
   private _spectaTopbar: ISpectaTopbarWidget;
+  private _layoutRegistry: ISpectaLayoutRegistry;
 }

--- a/src/specta_widget.ts
+++ b/src/specta_widget.ts
@@ -31,6 +31,8 @@ export class AppWidget extends Panel {
       this.addSpinner();
     }
 
+    this._currentLayoutName = options.spectaConfig.defaultLayout ?? 'default';
+
     this._model.initialize().then(async () => {
       let waitTime = this._spectaAppConfig.executionDelay;
       if (!waitTime) {
@@ -44,10 +46,6 @@ export class AppWidget extends Panel {
       await this.render();
       emitResizeEvent();
     });
-    this._layoutRegistry.selectedLayoutChanged.connect(
-      this._onSelectedLayoutChanged,
-      this
-    );
     this._model.fileChanged.connect((_, newCells) => {
       this.rerender(newCells);
     });
@@ -115,10 +113,32 @@ export class AppWidget extends Panel {
     return outs;
   }
 
+  get currentLayoutName(): string {
+    return this._currentLayoutName;
+  }
+
+  setCurrentLayout(name: string): void {
+    if (this._currentLayoutName === name) {
+      return;
+    }
+    this._currentLayoutName = name;
+    const spectaLayout = this.getLayout();
+    const currentEls = [...this._host.widgets];
+    currentEls.forEach(el => {
+      this._host.layout?.removeWidget(el);
+    });
+    spectaLayout.render({
+      host: this._host,
+      items: this._outputs,
+      notebook: this._model.context?.model.toJSON() as any,
+      readyCallback: async () => {},
+      spectaConfig: this._spectaAppConfig
+    });
+  }
+
   getLayout(): ISpectaLayout {
-    const layout = this._spectaAppConfig?.defaultLayout ?? 'default';
     const spectaLayout =
-      this._layoutRegistry.get(layout) ??
+      this._layoutRegistry.get(this._currentLayoutName) ??
       this._layoutRegistry.getDefaultLayout();
     return spectaLayout;
   }
@@ -170,25 +190,6 @@ export class AppWidget extends Panel {
     super.onCloseRequest(msg);
   }
 
-  private _onSelectedLayoutChanged(
-    sender: ISpectaLayoutRegistry,
-    args: { name: string; layout: ISpectaLayout; oldLayout?: ISpectaLayout }
-  ): void {
-    const { layout } = args;
-
-    const currentEls = [...this._host.widgets];
-
-    currentEls.forEach(el => {
-      this._host.layout?.removeWidget(el);
-    });
-    layout.render({
-      host: this._host,
-      items: this._outputs,
-      notebook: this._model.context?.model.toJSON() as any,
-      readyCallback: async () => {},
-      spectaConfig: this._spectaAppConfig
-    });
-  }
   private _model: AppModel;
 
   private _ready = new PromiseDelegate<void>();
@@ -202,6 +203,8 @@ export class AppWidget extends Panel {
   private _outputs: SpectaCellOutput[] = [];
 
   private _spectaAppConfig: ISpectaAppConfig;
+
+  private _currentLayoutName: string;
 }
 
 export namespace AppWidget {

--- a/src/specta_widget_factory.ts
+++ b/src/specta_widget_factory.ts
@@ -33,10 +33,6 @@ export class SpectaWidgetFactory {
       nbMetadata: context.model.metadata,
       nbPath: context.contentsModel?.path
     });
-
-    const defaultLayout = spectaConfig.defaultLayout ?? 'default';
-    this._options.spectaLayoutRegistry.setSelectedLayout(defaultLayout);
-
     const model = new AppModel({
       context,
       manager: this._options.manager,

--- a/src/topbar/index.tsx
+++ b/src/topbar/index.tsx
@@ -58,7 +58,11 @@ export const topbarPlugin: JupyterFrontEndPlugin<
     const title = <TitleComponent config={config.topBar} />;
     widget.addReactWidget(title, 'left', 0);
     const menu = (
-      <MenuComponent config={config.topBar} themeManager={themeManager} />
+      <MenuComponent
+        config={config.topBar}
+        themeManager={themeManager}
+        layoutRegistry={layoutRegistry}
+      />
     );
     widget.addReactWidget(menu, 'right', 10000);
 

--- a/src/topbar/menuComponent.tsx
+++ b/src/topbar/menuComponent.tsx
@@ -4,11 +4,16 @@ import React, { useState, useRef, useEffect } from 'react';
 import { GearIcon } from '../components/icon/gear';
 import { IconButton } from '../components/iconButton';
 import { SettingContent } from './settingDialog';
-import { ITopbarConfig } from '../token';
+import { ISpectaLayoutRegistry, ITopbarConfig } from '../token';
 
 interface IProps {
   config?: ITopbarConfig;
   themeManager?: IThemeManager;
+  layoutRegistry?: ISpectaLayoutRegistry;
+  spectaWidget?: {
+    currentLayoutName: string;
+    setCurrentLayout(name: string): void;
+  };
 }
 
 export function MenuComponent(props: IProps): JSX.Element {
@@ -46,6 +51,8 @@ export function MenuComponent(props: IProps): JSX.Element {
           <SettingContent
             config={props.config}
             themeManager={props.themeManager}
+            layoutRegistry={props.layoutRegistry}
+            spectaWidget={props.spectaWidget}
           />
         </div>
       )}

--- a/src/topbar/settingDialog.tsx
+++ b/src/topbar/settingDialog.tsx
@@ -7,6 +7,10 @@ export const SettingContent = (props: {
   config?: ITopbarConfig;
   themeManager?: IThemeManager;
   layoutRegistry?: ISpectaLayoutRegistry;
+  spectaWidget?: {
+    currentLayoutName: string;
+    setCurrentLayout(name: string): void;
+  };
 }) => {
   const { themeManager, layoutRegistry } = props;
   const [themeOptions, setThemeOptions] = useState<string[]>([
@@ -20,7 +24,9 @@ export const SettingContent = (props: {
     layoutRegistry?.allLayouts() ?? []
   );
   const [selectedLayout, setSelectedLayout] = useState<string>(
-    layoutRegistry?.selectedLayout?.name ?? 'default'
+    props.spectaWidget?.currentLayoutName ??
+      layoutRegistry?.selectedLayout?.name ??
+      'default'
   );
   useEffect(() => {
     let cb: any;
@@ -69,12 +75,16 @@ export const SettingContent = (props: {
   const onLayoutChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const layout = e.currentTarget?.value;
-      if (layout && layoutRegistry) {
-        layoutRegistry.setSelectedLayout(layout);
+      if (layout) {
+        if (props.spectaWidget) {
+          props.spectaWidget.setCurrentLayout(layout);
+        } else if (layoutRegistry) {
+          layoutRegistry.setSelectedLayout(layout);
+        }
         setSelectedLayout(layout);
       }
     },
-    [layoutRegistry]
+    [props.spectaWidget, layoutRegistry]
   );
   return (
     <div style={{ padding: '0 10px' }}>


### PR DESCRIPTION
This addresses issue #47 by using a local layout tracker for each tab `_currentLayoutName`, instead of a global one. 
This allows users to have multiple tabs with different specta views open simultaneously and switch between them.


https://github.com/user-attachments/assets/2c291b7d-5f26-479f-b2f8-80a4df576046



