### PR TITLE
Add Specta/JupyterLab button in topbar

### DIFF
--- a/src/token.ts
+++ b/src/token.ts
@@ -41,6 +41,7 @@ export interface ITopbarConfig {
   settingsButton?: boolean;
   themeToggle?: boolean;
   layoutToggle?: boolean;
+  openInToggle?: boolean;
   link?: string;
 }
 

--- a/src/topbar/menuComponent.tsx
+++ b/src/topbar/menuComponent.tsx
@@ -35,7 +35,7 @@ export function MenuComponent(props: IProps): JSX.Element {
   }, []);
 
   const isSpecta = isSpectaApp();
-  const showOpenInLab = isSpecta && (props.config?.openInToggle !== false);
+  const showOpenInLab = isSpecta && props.config?.openInToggle !== false;
   const showOpenInSpecta = !isSpecta;
 
   const openInApp = (app: 'lab' | 'specta') => {
@@ -49,23 +49,22 @@ export function MenuComponent(props: IProps): JSX.Element {
   };
 
   return (
-    <div className="specta-topbar-right" style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+    <div
+      className="specta-topbar-right"
+      style={{ display: 'flex', gap: '6px', alignItems: 'center' }}
+    >
       {showOpenInLab && (
         <IconButton
           onClick={() => openInApp('lab')}
           title="Open in JupyterLab"
-          icon={
-            <jupyterIcon.react width="23px" height="23px" />
-          }
+          icon={<jupyterIcon.react width="23px" height="23px" />}
         />
       )}
       {showOpenInSpecta && (
         <IconButton
           onClick={() => openInApp('specta')}
           title="Open in Standalone Specta"
-          icon={
-            <launchIcon.react width="23px" height="23px" />
-          }
+          icon={<launchIcon.react width="23px" height="23px" />}
         />
       )}
       <IconButton

--- a/src/topbar/menuComponent.tsx
+++ b/src/topbar/menuComponent.tsx
@@ -1,10 +1,13 @@
 import { IThemeManager } from '@jupyterlab/apputils';
+import { PageConfig } from '@jupyterlab/coreutils';
+import { jupyterIcon, launchIcon } from '@jupyterlab/ui-components';
 import React, { useState, useRef, useEffect } from 'react';
 
 import { GearIcon } from '../components/icon/gear';
 import { IconButton } from '../components/iconButton';
 import { SettingContent } from './settingDialog';
 import { ITopbarConfig } from '../token';
+import { isSpectaApp } from '../tool';
 
 interface IProps {
   config?: ITopbarConfig;
@@ -30,11 +33,45 @@ export function MenuComponent(props: IProps): JSX.Element {
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
+
+  const isSpecta = isSpectaApp();
+  const showOpenInLab = isSpecta && (props.config?.openInToggle !== false);
+  const showOpenInSpecta = !isSpecta;
+
+  const openInApp = (app: 'lab' | 'specta') => {
+    const baseUrl = PageConfig.getBaseUrl();
+    const urlParams = new URLSearchParams(window.location.search);
+    const path = urlParams.get('path');
+    const targetUrl = path
+      ? `${baseUrl}${app}/index.html?path=${encodeURIComponent(path)}`
+      : `${baseUrl}${app}/index.html`;
+    window.open(targetUrl, '_blank', 'noopener,noreferrer');
+  };
+
   return (
-    <div className="specta-topbar-right">
+    <div className="specta-topbar-right" style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+      {showOpenInLab && (
+        <IconButton
+          onClick={() => openInApp('lab')}
+          title="Open in JupyterLab"
+          icon={
+            <jupyterIcon.react width="23px" height="23px" />
+          }
+        />
+      )}
+      {showOpenInSpecta && (
+        <IconButton
+          onClick={() => openInApp('specta')}
+          title="Open in Standalone Specta"
+          icon={
+            <launchIcon.react width="23px" height="23px" />
+          }
+        />
+      )}
       <IconButton
         ref={buttonRef}
         onClick={() => setOpen(!open)}
+        title="Settings"
         icon={
           <GearIcon fill="var(--jp-ui-font-color2)" height={23} width={23} />
         }

--- a/style/base.css
+++ b/style/base.css
@@ -131,6 +131,17 @@
   transition: background 0.2s ease;
   background: transparent;
   padding: 0 !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  width: 28px !important;
+  height: 28px !important;
+}
+
+.specta-icon-button svg {
+  display: block !important;
+  width: 23px !important;
+  height: 23px !important;
 }
 
 .specta-icon-button:hover {


### PR DESCRIPTION
Added an `openInToggle` for the topbar which shows:
-A launchIcon to open the standalone specta app when on jupyterlab (or lite ig).
-A jupyterIcon to open the jupyterlab view.

https://github.com/user-attachments/assets/d432e60d-bb0e-4b85-950d-6161da9b557c

I'm wondering if we should use the jupyterlite icon instead of the jupyterlab icon.
Also we open a new tab when switching at the moment, I'm wondering if we should use the open tab instead.
Please let me know if you have any other remarks.