### PR TITLE
Add Select UI dropdown in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The following options are available:
 ```json
       "uiSwitcherOptions": [
         { "id": "lab", "label": "JupyterLab" },
-        { "id": "tree", "label": "Notebook" },
+        { "id": "notebooks", "label": "Notebook" },
         { "id": "specta", "label": "Specta" }
       ]
 ```

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ The following options are available:
       },
 ```
 
+- `uiSwitcherOptions`: List of UI options shown in the settings dropdown, allowing users to switch between different interfaces. Each entry has an `id` (the URL segment of the target app) and a `label` (the display name). Defaults to JupyterLab, Notebook, and Specta as a fallback.
+
+```json
+      "uiSwitcherOptions": [
+        { "id": "lab", "label": "JupyterLab" },
+        { "id": "tree", "label": "Notebook" },
+        { "id": "specta", "label": "Specta" }
+      ]
+```
+
 - `perFileConfig`: an object with key is the file path and value is the above configuration, it's used to have different layout/top bar config for each files, for example:
 
 ```json

--- a/demo/jupyter-lite.json
+++ b/demo/jupyter-lite.json
@@ -1,11 +1,27 @@
 {
   "jupyter-config-data": {
     "enableMemoryStorage": true,
-    "contentsStorageDrivers": ["memoryStorageDriver"],
+    "contentsStorageDrivers": [
+      "memoryStorageDriver"
+    ],
     "spectaConfig": {
       "topBar": {
         "title": "Specta Tree"
       },
+      "uiSwitcherOptions": [
+        {
+          "id": "lab",
+          "label": "JupyterLab"
+        },
+        {
+          "id": "tree",
+          "label": "Notebook"
+        },
+        {
+          "id": "specta",
+          "label": "Specta"
+        }
+      ],
       "defaultLayout": "default",
       "perFileConfig": {
         "blog.ipynb": {
@@ -26,8 +42,7 @@
       }
     },
     "disabledExtensions": [
-      "@jupyterlab/notebook-extension:open-with-no-kernel",
-      "@jupyterlite/application-extension:opener"
+      "@jupyterlab/notebook-extension:open-with-no-kernel"
     ]
   }
 }

--- a/demo/jupyter-lite.json
+++ b/demo/jupyter-lite.json
@@ -1,9 +1,7 @@
 {
   "jupyter-config-data": {
     "enableMemoryStorage": true,
-    "contentsStorageDrivers": [
-      "memoryStorageDriver"
-    ],
+    "contentsStorageDrivers": ["memoryStorageDriver"],
     "spectaConfig": {
       "topBar": {
         "title": "Specta Tree"
@@ -41,8 +39,6 @@
         "hideHeader": false
       }
     },
-    "disabledExtensions": [
-      "@jupyterlab/notebook-extension:open-with-no-kernel"
-    ]
+    "disabledExtensions": ["@jupyterlab/notebook-extension:open-with-no-kernel"]
   }
 }

--- a/demo/jupyter-lite.json
+++ b/demo/jupyter-lite.json
@@ -12,7 +12,7 @@
           "label": "JupyterLab"
         },
         {
-          "id": "tree",
+          "id": "notebooks",
           "label": "Notebook"
         },
         {

--- a/src/document/factory.tsx
+++ b/src/document/factory.tsx
@@ -9,7 +9,7 @@ import {
   ISpectaLayoutRegistry,
   ISpectaShell,
   ISpectaTopbarWidget,
-  ISpectaUrlFactory
+  ISpectaUiSwitcher
 } from '../token';
 import { isSpectaApp, readSpectaConfig } from '../tool';
 import { MenuComponent } from '../topbar/menuComponent';
@@ -24,7 +24,7 @@ interface IOptions extends DocumentRegistry.IWidgetFactoryOptions {
   shell: ISpectaShell;
   spectaLayoutRegistry: ISpectaLayoutRegistry;
   spectaTopbar: ISpectaTopbarWidget;
-  urlFactory?: ISpectaUrlFactory | null;
+  uiSwitcher?: ISpectaUiSwitcher | null;
 }
 
 export class NotebookGridWidgetFactory extends ABCWidgetFactory<
@@ -37,7 +37,7 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
     this._shell = options.shell;
     this._themeManager = options.themeManager;
     this._spectaTopbar = options.spectaTopbar;
-    this._urlFactory = options.urlFactory;
+    this._uiSwitcher = options.uiSwitcher;
   }
 
   protected createNewWidget(
@@ -59,7 +59,7 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
           <MenuComponent
             config={spectaConfig.topBar}
             themeManager={this._themeManager}
-            urlFactory={this._urlFactory}
+            uiSwitcher={this._uiSwitcher}
             currentPath={path}
             currentUi={isSpecta ? 'specta' : 'lab'}
           />
@@ -103,5 +103,5 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
   private _shell: ISpectaShell;
   private _themeManager?: IThemeManager;
   private _spectaTopbar: ISpectaTopbarWidget;
-  private _urlFactory?: ISpectaUrlFactory | null;
+  private _uiSwitcher?: ISpectaUiSwitcher | null;
 }

--- a/src/document/factory.tsx
+++ b/src/document/factory.tsx
@@ -8,7 +8,8 @@ import { SpectaWidgetFactory } from '../specta_widget_factory';
 import {
   ISpectaLayoutRegistry,
   ISpectaShell,
-  ISpectaTopbarWidget
+  ISpectaTopbarWidget,
+  ISpectaUrlFactory
 } from '../token';
 import { isSpectaApp, readSpectaConfig } from '../tool';
 import { MenuComponent } from '../topbar/menuComponent';
@@ -23,6 +24,7 @@ interface IOptions extends DocumentRegistry.IWidgetFactoryOptions {
   shell: ISpectaShell;
   spectaLayoutRegistry: ISpectaLayoutRegistry;
   spectaTopbar: ISpectaTopbarWidget;
+  urlFactory?: ISpectaUrlFactory | null;
 }
 
 export class NotebookGridWidgetFactory extends ABCWidgetFactory<
@@ -35,6 +37,7 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
     this._shell = options.shell;
     this._themeManager = options.themeManager;
     this._spectaTopbar = options.spectaTopbar;
+    this._urlFactory = options.urlFactory;
   }
 
   protected createNewWidget(
@@ -56,6 +59,9 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
           <MenuComponent
             config={spectaConfig.topBar}
             themeManager={this._themeManager}
+            urlFactory={this._urlFactory}
+            currentPath={path}
+            currentUi={isSpecta ? 'specta' : 'lab'}
           />
         );
         if (!isSpecta) {
@@ -97,4 +103,5 @@ export class NotebookGridWidgetFactory extends ABCWidgetFactory<
   private _shell: ISpectaShell;
   private _themeManager?: IThemeManager;
   private _spectaTopbar: ISpectaTopbarWidget;
+  private _urlFactory?: ISpectaUrlFactory | null;
 }

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -9,7 +9,7 @@ import {
   WidgetTracker
 } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
-import { PageConfig } from '@jupyterlab/coreutils';
+import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
@@ -101,7 +101,7 @@ export const spectaUrlFactory: JupyterFrontEndPlugin<ISpectaUrlFactory> = {
       const baseUrl = PageConfig.getBaseUrl();
       let appUrl = PageConfig.getOption('appUrl');
       if (!appUrl.endsWith('/')) {
-        appUrl += '/';
+        appUrl = `${appUrl}/`;
       }
       // Replace last segment of app URL with target UI 
       // (e.g. /foo/specta/ to /foo/lab/)
@@ -111,8 +111,7 @@ export const spectaUrlFactory: JupyterFrontEndPlugin<ISpectaUrlFactory> = {
       } else {
         parts.push(ui);
       }
-      const url = new URL(baseUrl);
-      url.pathname = '/' + parts.join('/') + '/';
+      const url = new URL(URLExt.join(baseUrl, '/' + parts.join('/') + '/'));
       // spectaOpener in lab mode reads 'specta-path'; specta app reads 'path'
       url.searchParams.set(ui === 'lab' ? 'specta-path' : 'path', path);
       const queries = PageConfig.getOption('query').split('&').filter(Boolean);

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -23,16 +23,15 @@ import {
   ISpectaShell,
   ISpectaTopbarWidget,
   ISpectaTopbarWidgetToken,
+  ISpectaUiSwitcher,
+  ISpectaUiSwitcherToken,
   ISpectaUrlFactory,
-  ISpectaUrlFactoryToken,
-  IUiOption
+  ISpectaUrlFactoryToken
 } from '../token';
 import {
-  configLabLayout,
   createFileBrowser,
   hideAppLoadingIndicator,
   isSpectaApp,
-  readSpectaConfig,
   registerDocumentFactory,
   getSpectaDocInfo,
   openDocument
@@ -48,7 +47,7 @@ const activate = (
   themeManager: IThemeManager,
   spectaTopbar: ISpectaTopbarWidget,
   kernelSpecManager: KernelSpec.IManager,
-  urlFactory: ISpectaUrlFactory | null
+  uiSwitcher: ISpectaUiSwitcher | null
 ): IWidgetTracker => {
   console.log('Specta document tracker active!'); // Test log here
   const namespace = 'specta';
@@ -66,7 +65,7 @@ const activate = (
     themeManager,
     spectaTopbar,
     kernelSpecManager,
-    urlFactory
+    uiSwitcher
   });
 
   return spectaTracker;
@@ -88,7 +87,7 @@ export const spectaDocument: JupyterFrontEndPlugin<
     ISpectaTopbarWidgetToken,
     IKernelSpecManager
   ],
-  optional: [ISpectaUrlFactoryToken],
+  optional: [ISpectaUiSwitcherToken],
   activate,
   provides: ISpectaDocTracker
 };
@@ -98,20 +97,16 @@ export const spectaUrlFactory: JupyterFrontEndPlugin<ISpectaUrlFactory> = {
   autoStart: true,
   provides: ISpectaUrlFactoryToken,
   activate: () => {
-    console.log('Specta urlFactory plugin activated (local version)');
-    const uis: IUiOption[] = [
-      { id: 'lab', label: 'JupyterLab' },
-      { id: 'specta', label: 'Specta' }
-    ];
     const segments: Record<string, string> = {
       lab: 'lab',
       specta: 'specta'
     };
-    const urlFactory = (path: string, ui = 'specta'): string => {
+    return (path: string, ui = 'specta'): string => {
       const baseUrl = PageConfig.getBaseUrl();
       const segment = segments[ui] ?? ui;
       const url = new URL(URLExt.join(baseUrl, segment, 'index.html'));
-      url.searchParams.set('path', path);
+      // spectaOpener in lab mode reads 'specta-path'; specta app reads 'path'
+      url.searchParams.set(ui === 'lab' ? 'specta-path' : 'path', path);
       const queries = PageConfig.getOption('query').split('&').filter(Boolean);
       queries.forEach(query => {
         const [key, value] = query.split('=');
@@ -119,7 +114,24 @@ export const spectaUrlFactory: JupyterFrontEndPlugin<ISpectaUrlFactory> = {
       });
       return url.toString();
     };
-    return Object.assign(urlFactory, { uis });
+  }
+};
+
+export const spectaUiSwitcher: JupyterFrontEndPlugin<ISpectaUiSwitcher> = {
+  id: 'specta/application-extension:uiSwitcher',
+  autoStart: true,
+  requires: [ISpectaUrlFactoryToken],
+  provides: ISpectaUiSwitcherToken,
+  activate: (_app, urlFactory: ISpectaUrlFactory) => {
+    return {
+      uis: [
+        { id: 'lab', label: 'JupyterLab' },
+        { id: 'specta', label: 'Specta' }
+      ],
+      switchTo: (path: string, ui: string) => {
+        window.location.assign(urlFactory(path, ui));
+      }
+    };
   }
 };
 
@@ -151,19 +163,13 @@ export const spectaOpener: JupyterFrontEndPlugin<void, ILabShell> = {
         return;
       }
       app.restored.then(async () => {
-        const labShell = app.shell;
-
-        const { isSpectaDoc, factory } = getSpectaDocInfo(path, app);
-
+        const { isSpectaDoc } = getSpectaDocInfo(path, app);
         if (isSpectaDoc) {
-          const commands = app.commands;
-          const spectaConfig = readSpectaConfig({});
-          await configLabLayout({
-            config: spectaConfig.labConfig,
-            labShell,
-            commands
-          });
-          openDocument(path, factory, docManager, app.shell);
+          // Open with the default factory so the full regular lab UI is preserved
+          const widget = docManager.openOrReveal(path);
+          if (widget) {
+            app.shell.add(widget, 'main');
+          }
         }
       });
       return;

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -135,7 +135,7 @@ export const spectaUiSwitcher: JupyterFrontEndPlugin<ISpectaUiSwitcher> = {
     const globalConfig = rawConfig ? JSON.parse(rawConfig) : {};
     const uis: IUiOption[] = globalConfig.uiSwitcherOptions ?? [
       { id: 'lab', label: 'JupyterLab' },
-      { id: 'tree', label: 'Notebook' },
+      { id: 'notebooks', label: 'Notebook' },
       { id: 'specta', label: 'Specta' }
     ];
     return {

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -35,7 +35,6 @@ import {
   registerDocumentFactory,
   getSpectaDocInfo,
   openDocument
-
 } from '../tool';
 
 const activate = (

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -133,14 +133,15 @@ export const spectaUiSwitcher: JupyterFrontEndPlugin<ISpectaUiSwitcher> = {
   activate: (_app, urlFactory: ISpectaUrlFactory) => {
     const rawConfig = PageConfig.getOption('spectaConfig');
     const globalConfig = rawConfig ? JSON.parse(rawConfig) : {};
-    const uis: IUiOption[] = globalConfig.uis ?? [
+    const uis: IUiOption[] = globalConfig.uiSwitcherOptions ?? [
       { id: 'lab', label: 'JupyterLab' },
+      { id: 'tree', label: 'Notebook' },
       { id: 'specta', label: 'Specta' }
     ];
     return {
       uis,
       switchTo: (path: string, ui: string) => {
-        window.location.assign(urlFactory(path, ui));
+        window.open(urlFactory(path, ui), '_blank');
       }
     };
   }

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -9,7 +9,7 @@ import {
   WidgetTracker
 } from '@jupyterlab/apputils';
 import { IEditorServices } from '@jupyterlab/codeeditor';
-import { PageConfig, URLExt } from '@jupyterlab/coreutils';
+import { PageConfig } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
 import { IDefaultFileBrowser } from '@jupyterlab/filebrowser';
 import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
@@ -26,7 +26,8 @@ import {
   ISpectaUiSwitcher,
   ISpectaUiSwitcherToken,
   ISpectaUrlFactory,
-  ISpectaUrlFactoryToken
+  ISpectaUrlFactoryToken,
+  IUiOption
 } from '../token';
 import {
   createFileBrowser,
@@ -96,14 +97,22 @@ export const spectaUrlFactory: JupyterFrontEndPlugin<ISpectaUrlFactory> = {
   autoStart: true,
   provides: ISpectaUrlFactoryToken,
   activate: () => {
-    const segments: Record<string, string> = {
-      lab: 'lab',
-      specta: 'specta'
-    };
-    return (path: string, ui = 'specta'): string => {
+    const urlFactory = (path: string, ui = 'specta'): string => {
       const baseUrl = PageConfig.getBaseUrl();
-      const segment = segments[ui] ?? ui;
-      const url = new URL(URLExt.join(baseUrl, segment, 'index.html'));
+      let appUrl = PageConfig.getOption('appUrl');
+      if (!appUrl.endsWith('/')) {
+        appUrl += '/';
+      }
+      // Replace last segment of app URL with target UI 
+      // (e.g. /foo/specta/ to /foo/lab/)
+      const parts = appUrl.split('/').filter(Boolean);
+      if (parts.length > 0) {
+        parts[parts.length - 1] = ui;
+      } else {
+        parts.push(ui);
+      }
+      const url = new URL(baseUrl);
+      url.pathname = '/' + parts.join('/') + '/';
       // spectaOpener in lab mode reads 'specta-path'; specta app reads 'path'
       url.searchParams.set(ui === 'lab' ? 'specta-path' : 'path', path);
       const queries = PageConfig.getOption('query').split('&').filter(Boolean);
@@ -113,6 +122,7 @@ export const spectaUrlFactory: JupyterFrontEndPlugin<ISpectaUrlFactory> = {
       });
       return url.toString();
     };
+    return urlFactory;
   }
 };
 
@@ -122,11 +132,14 @@ export const spectaUiSwitcher: JupyterFrontEndPlugin<ISpectaUiSwitcher> = {
   requires: [ISpectaUrlFactoryToken],
   provides: ISpectaUiSwitcherToken,
   activate: (_app, urlFactory: ISpectaUrlFactory) => {
+    const rawConfig = PageConfig.getOption('spectaConfig');
+    const globalConfig = rawConfig ? JSON.parse(rawConfig) : {};
+    const uis: IUiOption[] = globalConfig.uis ?? [
+      { id: 'lab', label: 'JupyterLab' },
+      { id: 'specta', label: 'Specta' }
+    ];
     return {
-      uis: [
-        { id: 'lab', label: 'JupyterLab' },
-        { id: 'specta', label: 'Specta' }
-      ],
+      uis,
       switchTo: (path: string, ui: string) => {
         window.location.assign(urlFactory(path, ui));
       }

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -24,7 +24,8 @@ import {
   ISpectaTopbarWidget,
   ISpectaTopbarWidgetToken,
   ISpectaUrlFactory,
-  ISpectaUrlFactoryToken
+  ISpectaUrlFactoryToken,
+  IUiOption
 } from '../token';
 import {
   configLabLayout,
@@ -46,8 +47,10 @@ const activate = (
   spectaLayoutRegistry: ISpectaLayoutRegistry,
   themeManager: IThemeManager,
   spectaTopbar: ISpectaTopbarWidget,
-  kernelSpecManager: KernelSpec.IManager
+  kernelSpecManager: KernelSpec.IManager,
+  urlFactory: ISpectaUrlFactory | null
 ): IWidgetTracker => {
+  console.log('Specta document tracker active!'); // Test log here
   const namespace = 'specta';
   const spectaTracker = new WidgetTracker<Widget>({ namespace });
 
@@ -62,7 +65,8 @@ const activate = (
     spectaLayoutRegistry,
     themeManager,
     spectaTopbar,
-    kernelSpecManager
+    kernelSpecManager,
+    urlFactory
   });
 
   return spectaTracker;
@@ -84,6 +88,7 @@ export const spectaDocument: JupyterFrontEndPlugin<
     ISpectaTopbarWidgetToken,
     IKernelSpecManager
   ],
+  optional: [ISpectaUrlFactoryToken],
   activate,
   provides: ISpectaDocTracker
 };
@@ -93,13 +98,19 @@ export const spectaUrlFactory: JupyterFrontEndPlugin<ISpectaUrlFactory> = {
   autoStart: true,
   provides: ISpectaUrlFactoryToken,
   activate: () => {
-    const urlFactory = (path: string) => {
+    console.log('Specta urlFactory plugin activated (local version)');
+    const uis: IUiOption[] = [
+      { id: 'lab', label: 'JupyterLab' },
+      { id: 'specta', label: 'Specta' }
+    ];
+    const segments: Record<string, string> = {
+      lab: 'lab',
+      specta: 'specta'
+    };
+    const urlFactory = (path: string, ui = 'specta'): string => {
       const baseUrl = PageConfig.getBaseUrl();
-      let appUrl = PageConfig.getOption('appUrl');
-      if (!appUrl.endsWith('/')) {
-        appUrl = `${appUrl}/`;
-      }
-      const url = new URL(URLExt.join(baseUrl, appUrl));
+      const segment = segments[ui] ?? ui;
+      const url = new URL(URLExt.join(baseUrl, segment, 'index.html'));
       url.searchParams.set('path', path);
       const queries = PageConfig.getOption('query').split('&').filter(Boolean);
       queries.forEach(query => {
@@ -108,7 +119,7 @@ export const spectaUrlFactory: JupyterFrontEndPlugin<ISpectaUrlFactory> = {
       });
       return url.toString();
     };
-    return urlFactory;
+    return Object.assign(urlFactory, { uis });
   }
 };
 

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -49,7 +49,6 @@ const activate = (
   kernelSpecManager: KernelSpec.IManager,
   uiSwitcher: ISpectaUiSwitcher | null
 ): IWidgetTracker => {
-  console.log('Specta document tracker active!'); // Test log here
   const namespace = 'specta';
   const spectaTracker = new WidgetTracker<Widget>({ namespace });
 

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -35,6 +35,7 @@ import {
   registerDocumentFactory,
   getSpectaDocInfo,
   openDocument
+
 } from '../tool';
 
 const activate = (
@@ -163,13 +164,9 @@ export const spectaOpener: JupyterFrontEndPlugin<void, ILabShell> = {
         return;
       }
       app.restored.then(async () => {
-        const { isSpectaDoc } = getSpectaDocInfo(path, app);
+        const { isSpectaDoc, factory } = getSpectaDocInfo(path, app);
         if (isSpectaDoc) {
-          // Open with the default factory so the full regular lab UI is preserved
-          const widget = docManager.openOrReveal(path);
-          if (widget) {
-            app.shell.add(widget, 'main');
-          }
+          openDocument(path, factory, docManager, app.shell);
         }
       });
       return;

--- a/src/document/plugin.ts
+++ b/src/document/plugin.ts
@@ -103,7 +103,7 @@ export const spectaUrlFactory: JupyterFrontEndPlugin<ISpectaUrlFactory> = {
       if (!appUrl.endsWith('/')) {
         appUrl = `${appUrl}/`;
       }
-      // Replace last segment of app URL with target UI 
+      // Replace last segment of app URL with target UI
       // (e.g. /foo/specta/ to /foo/lab/)
       const parts = appUrl.split('/').filter(Boolean);
       if (parts.length > 0) {

--- a/src/extension_plugins.ts
+++ b/src/extension_plugins.ts
@@ -1,6 +1,7 @@
 import {
   spectaDocument,
   spectaOpener,
+  spectaUiSwitcher,
   spectaUrlFactory
 } from './document/plugin';
 import { spectaLayoutRegistry } from './layout';
@@ -17,5 +18,6 @@ export default [
   topbarPlugin,
   appMeta,
   cellMeta,
-  spectaUrlFactory
+  spectaUrlFactory,
+  spectaUiSwitcher
 ];

--- a/src/token.ts
+++ b/src/token.ts
@@ -69,9 +69,10 @@ export interface IUiOption {
   id: string;
   label: string;
 }
-export interface ISpectaUrlFactory {
-  (path: string, ui?: string): string;
-  readonly uis: IUiOption[];
+export type ISpectaUrlFactory = (path: string, ui?: string) => string;
+export interface ISpectaUiSwitcher {
+  uis: IUiOption[];
+  switchTo: (path: string, ui: string) => void;
 }
 export const ISpectaLayoutRegistry = new Token<ISpectaLayoutRegistry>(
   'specta:ISpectaLayoutRegistry'
@@ -83,6 +84,9 @@ export const ISpectaDocTracker = new Token<IWidgetTracker<Widget>>(
 
 export const ISpectaUrlFactoryToken = new Token<ISpectaUrlFactory>(
   'specta:ISpectaUrlFactoryToken'
+);
+export const ISpectaUiSwitcherToken = new Token<ISpectaUiSwitcher>(
+  'specta:ISpectaUiSwitcherToken'
 );
 
 export interface ISpectaTopbarWidget {

--- a/src/token.ts
+++ b/src/token.ts
@@ -65,7 +65,14 @@ export interface ISpectaCellConfig {
   showOutput?: boolean;
   outputSize?: 'Small' | 'Big' | 'Full';
 }
-export type ISpectaUrlFactory = (path: string) => string;
+export interface IUiOption {
+  id: string;
+  label: string;
+}
+export interface ISpectaUrlFactory {
+  (path: string, ui?: string): string;
+  readonly uis: IUiOption[];
+}
 export const ISpectaLayoutRegistry = new Token<ISpectaLayoutRegistry>(
   'specta:ISpectaLayoutRegistry'
 );

--- a/src/token.ts
+++ b/src/token.ts
@@ -51,6 +51,7 @@ export interface ISpectaAppConfig {
   slidesTheme?: string;
   loadingName?: string;
   executionDelay?: number;
+  uis?: IUiOption[];
   labConfig?: {
     setSingleMode?: boolean;
     hideLeftPanel?: boolean;

--- a/src/token.ts
+++ b/src/token.ts
@@ -51,7 +51,7 @@ export interface ISpectaAppConfig {
   slidesTheme?: string;
   loadingName?: string;
   executionDelay?: number;
-  uis?: IUiOption[];
+  uiSwitcherOptions?: IUiOption[];
   labConfig?: {
     setSingleMode?: boolean;
     hideLeftPanel?: boolean;

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -57,6 +57,7 @@ export function registerDocumentFactory(options: {
   themeManager?: IThemeManager;
   spectaTopbar: ISpectaTopbarWidget;
   kernelSpecManager: KernelSpec.IManager;
+  urlFactory?: ISpectaUrlFactory | null;
 }) {
   const {
     factoryName,
@@ -69,7 +70,8 @@ export function registerDocumentFactory(options: {
     spectaLayoutRegistry,
     themeManager,
     spectaTopbar,
-    kernelSpecManager
+    kernelSpecManager,
+    urlFactory
   } = options;
 
   const spectaWidgetFactory = new SpectaWidgetFactory({
@@ -90,7 +92,8 @@ export function registerDocumentFactory(options: {
     spectaWidgetFactory,
     themeManager,
     spectaLayoutRegistry,
-    spectaTopbar
+    spectaTopbar,
+    urlFactory
   });
 
   // Registering the widget factory
@@ -134,7 +137,8 @@ export function registerDocumentFactory(options: {
       spectaWidgetFactory,
       themeManager,
       spectaLayoutRegistry,
-      spectaTopbar
+      spectaTopbar,
+      urlFactory
     });
 
     app.docRegistry.addWidgetFactory(plainbWidgetFactory);

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -19,6 +19,7 @@ import {
   ISpectaLayoutRegistry,
   ISpectaShell,
   ISpectaTopbarWidget,
+  ISpectaUiSwitcher,
   ISpectaUrlFactory
 } from './token';
 
@@ -57,7 +58,7 @@ export function registerDocumentFactory(options: {
   themeManager?: IThemeManager;
   spectaTopbar: ISpectaTopbarWidget;
   kernelSpecManager: KernelSpec.IManager;
-  urlFactory?: ISpectaUrlFactory | null;
+  uiSwitcher?: ISpectaUiSwitcher | null;
 }) {
   const {
     factoryName,
@@ -71,7 +72,7 @@ export function registerDocumentFactory(options: {
     themeManager,
     spectaTopbar,
     kernelSpecManager,
-    urlFactory
+    uiSwitcher
   } = options;
 
   const spectaWidgetFactory = new SpectaWidgetFactory({
@@ -93,7 +94,7 @@ export function registerDocumentFactory(options: {
     themeManager,
     spectaLayoutRegistry,
     spectaTopbar,
-    urlFactory
+    uiSwitcher
   });
 
   // Registering the widget factory
@@ -138,7 +139,7 @@ export function registerDocumentFactory(options: {
       themeManager,
       spectaLayoutRegistry,
       spectaTopbar,
-      urlFactory
+      uiSwitcher
     });
 
     app.docRegistry.addWidgetFactory(plainbWidgetFactory);

--- a/src/topbar/index.tsx
+++ b/src/topbar/index.tsx
@@ -10,7 +10,9 @@ import {
   ISpectaLayoutRegistry,
   ISpectaShell,
   ISpectaTopbarWidget,
-  ISpectaTopbarWidgetToken
+  ISpectaTopbarWidgetToken,
+  ISpectaUrlFactory,
+  ISpectaUrlFactoryToken
 } from '../token';
 import { isSpectaApp, readSpectaConfig, PLAINB_PREFIX } from '../tool';
 import { MenuComponent } from './menuComponent';
@@ -25,11 +27,13 @@ export const topbarPlugin: JupyterFrontEndPlugin<
   description: 'Specta topbar extension',
   autoStart: true,
   requires: [IThemeManager, ISpectaLayoutRegistry],
+  optional: [ISpectaUrlFactoryToken],
   provides: ISpectaTopbarWidgetToken,
   activate: (
     app: JupyterFrontEnd<ISpectaShell>,
     themeManager: IThemeManager,
-    layoutRegistry: ISpectaLayoutRegistry
+    layoutRegistry: ISpectaLayoutRegistry,
+    urlFactory: ISpectaUrlFactory | null
   ) => {
     const isSpecta = isSpectaApp();
     if (!isSpecta) {
@@ -60,7 +64,13 @@ export const topbarPlugin: JupyterFrontEndPlugin<
     const title = <TitleComponent config={config.topBar} />;
     widget.addReactWidget(title, 'left', 0);
     const menu = (
-      <MenuComponent config={config.topBar} themeManager={themeManager} />
+      <MenuComponent
+        config={config.topBar}
+        themeManager={themeManager}
+        urlFactory={urlFactory}
+        currentPath={path}
+        currentUi={isSpecta ? 'specta' : 'lab'}
+      />
     );
     widget.addReactWidget(menu, 'right', 10000);
 

--- a/src/topbar/index.tsx
+++ b/src/topbar/index.tsx
@@ -11,8 +11,8 @@ import {
   ISpectaShell,
   ISpectaTopbarWidget,
   ISpectaTopbarWidgetToken,
-  ISpectaUrlFactory,
-  ISpectaUrlFactoryToken
+  ISpectaUiSwitcher,
+  ISpectaUiSwitcherToken
 } from '../token';
 import { isSpectaApp, readSpectaConfig, PLAINB_PREFIX } from '../tool';
 import { MenuComponent } from './menuComponent';
@@ -27,13 +27,13 @@ export const topbarPlugin: JupyterFrontEndPlugin<
   description: 'Specta topbar extension',
   autoStart: true,
   requires: [IThemeManager, ISpectaLayoutRegistry],
-  optional: [ISpectaUrlFactoryToken],
+  optional: [ISpectaUiSwitcherToken],
   provides: ISpectaTopbarWidgetToken,
   activate: (
     app: JupyterFrontEnd<ISpectaShell>,
     themeManager: IThemeManager,
     layoutRegistry: ISpectaLayoutRegistry,
-    urlFactory: ISpectaUrlFactory | null
+    uiSwitcher: ISpectaUiSwitcher | null
   ) => {
     const isSpecta = isSpectaApp();
     if (!isSpecta) {
@@ -67,7 +67,7 @@ export const topbarPlugin: JupyterFrontEndPlugin<
       <MenuComponent
         config={config.topBar}
         themeManager={themeManager}
-        urlFactory={urlFactory}
+        uiSwitcher={uiSwitcher}
         currentPath={path}
         currentUi={isSpecta ? 'specta' : 'lab'}
       />

--- a/src/topbar/menuComponent.tsx
+++ b/src/topbar/menuComponent.tsx
@@ -4,12 +4,12 @@ import React, { useState, useRef, useEffect } from 'react';
 import { GearIcon } from '../components/icon/gear';
 import { IconButton } from '../components/iconButton';
 import { SettingContent } from './settingDialog';
-import { ISpectaUrlFactory, ITopbarConfig } from '../token';
+import { ISpectaUiSwitcher, ITopbarConfig } from '../token';
 
 interface IProps {
   config?: ITopbarConfig;
   themeManager?: IThemeManager;
-  urlFactory?: ISpectaUrlFactory | null;
+  uiSwitcher?: ISpectaUiSwitcher | null;
   currentPath?: string | null;
   currentUi?: string;
 }
@@ -49,7 +49,7 @@ export function MenuComponent(props: IProps): JSX.Element {
           <SettingContent
             config={props.config}
             themeManager={props.themeManager}
-            urlFactory={props.urlFactory}
+            uiSwitcher={props.uiSwitcher}
             currentPath={props.currentPath}
             currentUi={props.currentUi}
           />

--- a/src/topbar/menuComponent.tsx
+++ b/src/topbar/menuComponent.tsx
@@ -4,11 +4,14 @@ import React, { useState, useRef, useEffect } from 'react';
 import { GearIcon } from '../components/icon/gear';
 import { IconButton } from '../components/iconButton';
 import { SettingContent } from './settingDialog';
-import { ITopbarConfig } from '../token';
+import { ISpectaUrlFactory, ITopbarConfig } from '../token';
 
 interface IProps {
   config?: ITopbarConfig;
   themeManager?: IThemeManager;
+  urlFactory?: ISpectaUrlFactory | null;
+  currentPath?: string | null;
+  currentUi?: string;
 }
 
 export function MenuComponent(props: IProps): JSX.Element {
@@ -46,6 +49,9 @@ export function MenuComponent(props: IProps): JSX.Element {
           <SettingContent
             config={props.config}
             themeManager={props.themeManager}
+            urlFactory={props.urlFactory}
+            currentPath={props.currentPath}
+            currentUi={props.currentUi}
           />
         </div>
       )}

--- a/src/topbar/settingDialog.tsx
+++ b/src/topbar/settingDialog.tsx
@@ -164,7 +164,7 @@ export const SettingContent = (props: {
             <select
               className=" jp-mod-styled specta-topbar-theme"
               onChange={onUiChange}
-              defaultValue={props.currentUi}
+              value={props.currentUi}
             >
               {uiSwitcher.uis.map(ui => {
                 return (

--- a/src/topbar/settingDialog.tsx
+++ b/src/topbar/settingDialog.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { Divider } from '../components/divider';
 import {
   ISpectaLayoutRegistry,
-  ISpectaUrlFactory,
+  ISpectaUiSwitcher,
   ITopbarConfig
 } from '../token';
 
@@ -11,7 +11,7 @@ export const SettingContent = (props: {
   config?: ITopbarConfig;
   themeManager?: IThemeManager;
   layoutRegistry?: ISpectaLayoutRegistry;
-  urlFactory?: ISpectaUrlFactory | null;
+  uiSwitcher?: ISpectaUiSwitcher | null;
   currentPath?: string | null;
   currentUi?: string;
 }) => {
@@ -83,15 +83,15 @@ export const SettingContent = (props: {
     },
     [layoutRegistry]
   );
-  const { urlFactory, currentPath } = props;
+  const { uiSwitcher, currentPath } = props;
   const onUiChange = useCallback(
     (e: React.ChangeEvent<HTMLSelectElement>) => {
       const ui = e.currentTarget?.value;
-      if (ui && urlFactory && currentPath) {
-        window.location.assign(urlFactory(currentPath, ui));
+      if (ui && uiSwitcher && currentPath) {
+        uiSwitcher.switchTo(currentPath, ui);
       }
     },
-    [urlFactory, currentPath]
+    [uiSwitcher, currentPath]
   );
   return (
     <div style={{ padding: '0 10px' }}>
@@ -157,7 +157,7 @@ export const SettingContent = (props: {
             </div>
           </div>
         )}
-      {currentPath && urlFactory && urlFactory.uis.length > 0 && (
+      {currentPath && uiSwitcher && uiSwitcher.uis.length > 0 && (
         <div>
           <label htmlFor="">Select UI</label>
           <div className="jp-select-wrapper">
@@ -166,7 +166,7 @@ export const SettingContent = (props: {
               onChange={onUiChange}
               defaultValue={props.currentUi}
             >
-              {urlFactory.uis.map(ui => {
+              {uiSwitcher.uis.map(ui => {
                 return (
                   <option
                     key={ui.id}

--- a/src/topbar/settingDialog.tsx
+++ b/src/topbar/settingDialog.tsx
@@ -1,12 +1,19 @@
 import { IThemeManager } from '@jupyterlab/apputils';
 import React, { useState, useEffect, useCallback } from 'react';
 import { Divider } from '../components/divider';
-import { ISpectaLayoutRegistry, ITopbarConfig } from '../token';
+import {
+  ISpectaLayoutRegistry,
+  ISpectaUrlFactory,
+  ITopbarConfig
+} from '../token';
 
 export const SettingContent = (props: {
   config?: ITopbarConfig;
   themeManager?: IThemeManager;
   layoutRegistry?: ISpectaLayoutRegistry;
+  urlFactory?: ISpectaUrlFactory | null;
+  currentPath?: string | null;
+  currentUi?: string;
 }) => {
   const { themeManager, layoutRegistry } = props;
   const [themeOptions, setThemeOptions] = useState<string[]>([
@@ -76,6 +83,16 @@ export const SettingContent = (props: {
     },
     [layoutRegistry]
   );
+  const { urlFactory, currentPath } = props;
+  const onUiChange = useCallback(
+    (e: React.ChangeEvent<HTMLSelectElement>) => {
+      const ui = e.currentTarget?.value;
+      if (ui && urlFactory && currentPath) {
+        window.location.assign(urlFactory(currentPath, ui));
+      }
+    },
+    [urlFactory, currentPath]
+  );
   return (
     <div style={{ padding: '0 10px' }}>
       <p style={{ marginTop: 0, marginBottom: '5px', fontSize: '1rem' }}>
@@ -140,6 +157,30 @@ export const SettingContent = (props: {
             </div>
           </div>
         )}
+      {currentPath && urlFactory && urlFactory.uis.length > 0 && (
+        <div>
+          <label htmlFor="">Select UI</label>
+          <div className="jp-select-wrapper">
+            <select
+              className=" jp-mod-styled specta-topbar-theme"
+              onChange={onUiChange}
+              defaultValue={props.currentUi}
+            >
+              {urlFactory.uis.map(ui => {
+                return (
+                  <option
+                    key={ui.id}
+                    value={ui.id}
+                    style={{ background: 'var(--jp-layout-color2)' }}
+                  >
+                    {ui.label}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This is supposed to replace PR #51 
I'm not too sure about some of the architectural choices (I thought about making `uis` optional to not break backwards compatibility, but I think it would be just easier to update the jupyterlite-bootstrap which seems to be the only project using specta afaik).

I still need to make switching from the specta standalone app to jupyterlab open the active notebook instead of the launcher tab.
