### PR TITLE
Make cell borders configurable

### DIFF
--- a/schema/app-meta.json
+++ b/schema/app-meta.json
@@ -51,10 +51,20 @@
               "white"
             ],
             "default": null
+          },
+          "/specta/showBorders": {
+            "title": "Show cell borders",
+            "type": "string",
+            "enum": ["Yes", "No"],
+            "default": "No"
           }
         }
       },
       "metadataOptions": {
+        "/specta/showBorders": {
+          "metadataLevel": "notebook",
+          "writeDefault": false
+        },
         "/specta/hideTopbar": {
           "metadataLevel": "notebook",
           "writeDefault": false

--- a/src/layout/article.ts
+++ b/src/layout/article.ts
@@ -1,12 +1,15 @@
 import { Panel, Widget } from '@lumino/widgets';
 import { SpectaCellOutput } from '../specta_cell_output';
 import * as nbformat from '@jupyterlab/nbformat';
-import { ISpectaLayout } from '../token';
+import { ISpectaAppConfig, ISpectaLayout } from '../token';
 
 class HostPanel extends Panel {
-  constructor() {
+  constructor(showBorders?: boolean) {
     super();
     this.addClass('specta-article-host-widget');
+    if (showBorders) {
+      this.addClass('specta-show-borders');
+    }
     this._outputs = new Panel();
     this._outputs.addClass('specta-article-outputs-panel');
     this.addWidget(this._outputs);
@@ -23,9 +26,10 @@ export class ArticleLayout implements ISpectaLayout {
     items: SpectaCellOutput[];
     notebook: nbformat.INotebookContent;
     readyCallback: () => Promise<void>;
+    spectaConfig?: ISpectaAppConfig;
   }): Promise<void> {
-    const { host, items, readyCallback } = options;
-    const hostPanel = new HostPanel();
+    const { host, items, readyCallback, spectaConfig } = options;
+    const hostPanel = new HostPanel(spectaConfig?.showBorders);
     for (const el of items) {
       const cellModel = el.info.cellModel;
       const info = el.info;

--- a/src/token.ts
+++ b/src/token.ts
@@ -48,6 +48,7 @@ export interface ISpectaAppConfig {
   topBar?: ITopbarConfig;
   defaultLayout?: string;
   hideTopbar?: boolean;
+  showBorders?: boolean;
   slidesTheme?: string;
   loadingName?: string;
   executionDelay?: number;

--- a/src/tool.ts
+++ b/src/tool.ts
@@ -284,6 +284,12 @@ export function readSpectaConfig({
 
   const spectaMetadata = JSON.parse(JSON.stringify(nbMetadata?.specta ?? {}));
 
+  if (spectaMetadata.showBorders === 'Yes') {
+    spectaMetadata.showBorders = true;
+  } else if (spectaMetadata.showBorders === 'No') {
+    spectaMetadata.showBorders = false;
+  }
+
   if (spectaMetadata.hideTopbar === 'Yes') {
     spectaMetadata.hideTopbar = true;
   } else if (spectaMetadata.hideTopbar === 'No') {

--- a/style/article.css
+++ b/style/article.css
@@ -95,11 +95,22 @@
     text-decoration: underline;
   }
 
+  &.specta-show-borders {
+    pre,
+    .jp-InputArea-editor {
+      border: 1px solid var(--jp-cell-editor-border-color) !important;
+    }
+    .jp-OutputArea {
+      border: 1px solid var(--jp-border-color2, var(--jp-cell-editor-border-color)) !important;
+      border-radius: 4px;
+    }
+  }
+
   pre {
     background-color: var(--jp-cell-editor-background) !important;
     padding: 32px !important;
     border-radius: 4px !important;
-    border: 1px solid var(--jp-cell-editor-border-color) !important;
+    border: none !important;
     overflow-x: auto;
     margin: 0 !important;
     margin-top: 56px !important;
@@ -203,6 +214,7 @@
   .jp-InputArea-editor {
     padding: 32px !important;
     border-radius: 4px !important;
+    border: none !important;
     background-color: var(--jp-cell-editor-background) !important;
   }
   .jp-InputArea-editor > div.cm-editor {


### PR DESCRIPTION
This PR removes default cell and output borders in Article layout and adds a `/specta/showBorders` notebook metadata setting to toggle them.