### PR TITLE
Fix default layout for notebooklink

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ If you want to disable specta loading spinner, you can set the environment varia
 
 Specta comes with three built-in layouts:
 
-- `default`: The default layout, which renders the notebook as a dashboard.
-- `article`: A minimal, blog-like reading experience.
+- `article`: The default layout, a minimal blog-like reading experience.
+- `dashboard`: Renders the notebook as a dashboard.
 - `slides`: A fullscreen presentation mode using [reveal.js](https://revealjs.com/).
 
 ### Top-level configuration

--- a/demo/jupyter-lite.json
+++ b/demo/jupyter-lite.json
@@ -20,7 +20,7 @@
           "label": "Specta"
         }
       ],
-      "defaultLayout": "default",
+      "defaultLayout": "article",
       "perFileConfig": {
         "blog.ipynb": {
           "hideTopbar": false,

--- a/schema/app-meta.json
+++ b/schema/app-meta.json
@@ -17,30 +17,19 @@
           "/specta/topbarThemeToggle": {
             "title": "Top Bar Theme Toggle",
             "type": "string",
-            "enum": [
-              "Yes",
-              "No"
-            ],
+            "enum": ["Yes", "No"],
             "default": "Yes"
           },
           "/specta/defaultLayout": {
             "title": "Page layout",
             "type": "string",
-            "enum": [
-              "default",
-              "article",
-              "slides"
-            ],
+            "enum": ["default", "article", "slides"],
             "default": "default"
           },
           "/specta/hideTopbar": {
             "title": "Hide topbar",
             "type": "string",
-            "enum": [
-              "Yes",
-              "No",
-              null
-            ],
+            "enum": ["Yes", "No", null],
             "default": null
           },
           "/specta/slidesTheme": {

--- a/schema/app-meta.json
+++ b/schema/app-meta.json
@@ -23,8 +23,8 @@
           "/specta/defaultLayout": {
             "title": "Page layout",
             "type": "string",
-            "enum": ["default", "article", "slides"],
-            "default": "default"
+            "enum": ["article", "dashboard", "slides"],
+            "default": "article"
           },
           "/specta/hideTopbar": {
             "title": "Hide topbar",
@@ -61,7 +61,7 @@
         },
         "/specta/defaultLayout": {
           "metadataLevel": "notebook",
-          "writeDefault": true
+          "writeDefault": false
         },
         "/specta/slidesTheme": {
           "metadataLevel": "notebook",

--- a/schema/app-meta.json
+++ b/schema/app-meta.json
@@ -17,19 +17,30 @@
           "/specta/topbarThemeToggle": {
             "title": "Top Bar Theme Toggle",
             "type": "string",
-            "enum": ["Yes", "No"],
+            "enum": [
+              "Yes",
+              "No"
+            ],
             "default": "Yes"
           },
           "/specta/defaultLayout": {
             "title": "Page layout",
             "type": "string",
-            "enum": ["default", "article", "slides"],
+            "enum": [
+              "default",
+              "article",
+              "slides"
+            ],
             "default": "default"
           },
           "/specta/hideTopbar": {
             "title": "Hide topbar",
             "type": "string",
-            "enum": ["Yes", "No", null],
+            "enum": [
+              "Yes",
+              "No",
+              null
+            ],
             "default": null
           },
           "/specta/slidesTheme": {
@@ -61,7 +72,7 @@
         },
         "/specta/defaultLayout": {
           "metadataLevel": "notebook",
-          "writeDefault": false
+          "writeDefault": true
         },
         "/specta/slidesTheme": {
           "metadataLevel": "notebook",

--- a/src/layout/default.ts
+++ b/src/layout/default.ts
@@ -3,7 +3,7 @@ import { SpectaCellOutput } from '../specta_cell_output';
 import * as nbformat from '@jupyterlab/nbformat';
 import { ISpectaLayout } from '../token';
 
-export class DefaultLayout implements ISpectaLayout {
+export class DashboardLayout implements ISpectaLayout {
   async render(options: {
     host: Panel;
     items: SpectaCellOutput[];

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -15,7 +15,7 @@ export const spectaLayoutRegistry: JupyterFrontEndPlugin<ISpectaLayoutRegistry> 
     activate: (app: JupyterFrontEnd): ISpectaLayoutRegistry => {
       const layoutRegistry = new SpectaLayoutRegistry();
       const spectaConfig = readSpectaConfig({});
-      const defaultLayout = spectaConfig.defaultLayout ?? 'default';
+      const defaultLayout = spectaConfig.defaultLayout ?? 'article';
       layoutRegistry.setSelectedLayout(defaultLayout);
       return layoutRegistry;
     }

--- a/src/layout/layout_registry.ts
+++ b/src/layout/layout_registry.ts
@@ -1,19 +1,20 @@
 import { ISignal, Signal } from '@lumino/signaling';
 import { ISpectaLayout, ISpectaLayoutRegistry } from '../token';
-import { DefaultLayout } from './default';
+import { DashboardLayout } from './default';
 import { ArticleLayout } from './article';
 import { SlidesLayout } from './slides';
 
 export class SpectaLayoutRegistry implements ISpectaLayoutRegistry {
   constructor() {
-    const defaultLayout = new DefaultLayout();
+    const dashboardLayout = new DashboardLayout();
+    const articleLayout = new ArticleLayout();
     this._registry = new Map<string, ISpectaLayout>();
-    this._registry.set('default', defaultLayout);
-    this._registry.set('article', new ArticleLayout());
+    this._registry.set('article', articleLayout);
+    this._registry.set('dashboard', dashboardLayout);
     this._registry.set('slides', new SlidesLayout());
     this._selectedLayout = {
-      name: 'default',
-      layout: defaultLayout
+      name: 'article',
+      layout: articleLayout
     };
   }
   get layoutAdded(): ISignal<SpectaLayoutRegistry, string> {
@@ -35,7 +36,7 @@ export class SpectaLayoutRegistry implements ISpectaLayoutRegistry {
   }
 
   getDefaultLayout(): ISpectaLayout {
-    return this._registry.get('default')!;
+    return this._registry.get('article')!;
   }
 
   async setSelectedLayout(name: string): Promise<void> {

--- a/src/specta_widget.ts
+++ b/src/specta_widget.ts
@@ -116,7 +116,7 @@ export class AppWidget extends Panel {
   }
 
   getLayout(): ISpectaLayout {
-    const layout = this._spectaAppConfig?.defaultLayout ?? 'default';
+    const layout = this._spectaAppConfig?.defaultLayout ?? 'article';
     const spectaLayout =
       this._layoutRegistry.get(layout) ??
       this._layoutRegistry.getDefaultLayout();

--- a/src/specta_widget_factory.ts
+++ b/src/specta_widget_factory.ts
@@ -34,7 +34,7 @@ export class SpectaWidgetFactory {
       nbPath: context.contentsModel?.path
     });
 
-    const defaultLayout = spectaConfig.defaultLayout ?? 'default';
+    const defaultLayout = spectaConfig.defaultLayout ?? 'article';
     this._options.spectaLayoutRegistry.setSelectedLayout(defaultLayout);
 
     const model = new AppModel({

--- a/src/topbar/settingDialog.tsx
+++ b/src/topbar/settingDialog.tsx
@@ -30,7 +30,7 @@ export const SettingContent = (props: {
     layoutRegistry?.allLayouts() ?? []
   );
   const [selectedLayout, setSelectedLayout] = useState<string>(
-    layoutRegistry?.selectedLayout?.name ?? 'default'
+    layoutRegistry?.selectedLayout?.name ?? 'article'
   );
   useEffect(() => {
     let cb: any;


### PR DESCRIPTION
This PR fixes issue #61 where setting the default layout in the metadata doesn't work. The issue happens because `/specta/defaultLayout` had `writeDefault: false`, which deleted `"defaultLayout": "default"` from notebook metadata when selected in notebook link, which causes it to fall back to its default layout which is "article".

This seems to be the only field for which setting the writeDefault value to false causes a bug, for the others no changes are needed since they're `null` by default and for the `topbarThemeToggle` because if it becomes undefined (when `writeDefault` is false) the code sets it to "Yes".

https://github.com/user-attachments/assets/0eed7b21-139b-4ed6-b334-552bf78f4648

