### PR TITLE
Align output cells in dashboard layout

### DIFF
--- a/style/base.css
+++ b/style/base.css
@@ -68,6 +68,14 @@
   flex-grow: 1;
 }
 
+.specta-cell-output .jp-OutputArea {
+  padding: var(--jp-cell-padding);
+  padding-left: calc(
+    var(--jp-cell-padding) + var(--jp-cell-prompt-width) +
+      var(--jp-code-padding)
+  );
+}
+
 #specta-top-panel {
   min-height: 28px;
   display: flex;


### PR DESCRIPTION
This PR fixes issue #49:

<img width="2312" height="1498" alt="image" src="https://github.com/user-attachments/assets/5ff9e18d-5abd-4615-bfdd-5db2346fa37b" />
